### PR TITLE
Reduce overhead of monitor pipeline

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const Os = require('os');
+const { pipeline } = require('stream');
 
 const Hoek = require('@hapi/hoek');
 const Oppsy = require('@hapi/oppsy');
-const Pumpify = require('pumpify');
 
 const Package = require('../package.json');
 const Utils = require('./utils');
@@ -119,15 +119,11 @@ module.exports = internals.Monitor = class {
                 streamObjs.push(stream);
             }
 
-            if (streamObjs.length === 1) {
-                streamObjs.unshift(new Utils.NoOp());
-            }
-
-            this._reporters.set(reporterName, Pumpify.obj(streamObjs)).get(reporterName).on('error', (err) => {
+            this._reporters.set(reporterName, setupPipeline(streamObjs, (err) => {
 
                 console.error(`There was a problem (${err}) in ${reporterName} and it has been destroyed.`);
                 console.error(err);
-            });
+            }));
         }
 
         this._state.report = true;
@@ -207,4 +203,23 @@ module.exports = internals.Monitor = class {
             }
         }
     }
+};
+
+const setupPipeline = (streams, onError) => {
+
+    const stream = streams[0];
+
+    if (streams.length === 1) {
+        stream.on('error', onError);
+    }
+    else {
+        pipeline(streams, (err) => {
+
+            if (err) {
+                onError(err);
+            }
+        });
+    }
+
+    return stream;
 };

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Os = require('os');
-const { pipeline } = require('stream');
+const { pipeline, finished } = require('stream');
 
 const Hoek = require('@hapi/hoek');
 const Oppsy = require('@hapi/oppsy');
@@ -121,8 +121,10 @@ module.exports = internals.Monitor = class {
 
             this._reporters.set(reporterName, setupPipeline(streamObjs, (err) => {
 
-                console.error(`There was a problem (${err}) in ${reporterName} and it has been destroyed.`);
-                console.error(err);
+                if (err) {
+                    console.error(`There was a problem (${err}) in ${reporterName} and it has been destroyed.`);
+                    console.error(err);
+                }
             }));
         }
 
@@ -205,20 +207,15 @@ module.exports = internals.Monitor = class {
     }
 };
 
-const setupPipeline = (streams, onError) => {
+const setupPipeline = (streams, onFinished) => {
 
     const stream = streams[0];
 
     if (streams.length === 1) {
-        stream.on('error', onError);
+        finished(stream, onFinished);
     }
     else {
-        pipeline(streams, (err) => {
-
-            if (err) {
-                onError(err);
-            }
-        });
+        pipeline(streams, onFinished);
     }
 
     return stream;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Stream = require('stream');
-
 const Hoek = require('@hapi/hoek');
 
 
@@ -166,19 +164,5 @@ exports.RequestLog = class {
         if (reqOptions.headers) {
             this.headers = Hoek.reach(request, 'raw.req.headers');
         }
-    }
-};
-
-
-exports.NoOp = class extends Stream.Transform {
-
-    constructor() {
-
-        super({ objectMode: true });
-    }
-
-    _transform(value, encoding, callback) {
-
-        callback(null, value);
     }
 };

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@hapi/hoek": "9.x.x",
     "@hapi/oppsy": "3.x.x",
-    "@hapi/validate": "1.x.x",
-    "pumpify": "2.x.x"
+    "@hapi/validate": "1.x.x"
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",

--- a/test/monitor.js
+++ b/test/monitor.js
@@ -91,7 +91,7 @@ describe('Monitor', () => {
         monitor.stop();
     });
 
-    it('logs and destroys a reporter in the event of a stream error', { plan: 3 }, () => {
+    it('logs and destroys a reporter in the event of a stream error', { plan: 3 }, async () => {
 
         const one = new Reporters.Incrementer(1);
         const two = new Reporters.Writer(true);
@@ -114,12 +114,20 @@ describe('Monitor', () => {
         // Verion 8 of node misses this change inside monitor, so force it here
         const foo = monitor._reporters.get('foo');
         foo.destroyed = true;
-        foo.emit('error');
+        foo.emit('error', new Error('bar'));
         monitor.push(() => ({ id: 3, number: 100 }));
 
         expect(two.data).to.have.length(2);
         expect(two.data).to.equal([{ id: 1, number: 3 }, { id: 2, number: 6 }]);
-        console.error = err;
+
+        await new Promise((resolve) => {
+
+            process.nextTick(() => {
+
+                console.error = err;
+                resolve();
+            });
+        });
     });
 
     describe('start()', () => {


### PR DESCRIPTION
This PR optimizes two things:

### Use `pipeline` over `pumpify`

This is mainly to fix an "issue" with Node.js 14 where `pumpify` requires a few extra ticks every time someone writes to the pipeline. This could result in the process crashing prior to the logger writing to its destination. For example, in the following example, the `data` event-listener would never be called before the process crashes because of the thrown error on Node.js 14:

```js
const Pumpify = require('pumpify')
const { PassThrough } = require('stream')
const a = new PassThrough()
const b = new PassThrough()
const pipe = Pumpify([a, b])
b.on('data', (chunk) => console.log('Got data:', chunk.toString()))
pipe.write('hello')
throw new Error('boom!')
```

However, the following would call the `data` event-listener on Node.js 14:

```js
const { PassThrough, pipeline } = require('stream')
const a = new PassThrough()
const b = new PassThrough()
pipeline(a, b, () => {})
b.on('data', (chunk) => console.log('Got data:', chunk.toString()))
a.write('hello')
throw new Error('boom!')
```

### Don't use pipeline if not required

In the case where there's only _one_ stream, there's no need to use a pipeline. Instead we can just write directly to the stream. This also reduces the overhead of the logger slightly.